### PR TITLE
Improve Grammar in Docs

### DIFF
--- a/src/game_sdk/game/README.md
+++ b/src/game_sdk/game/README.md
@@ -29,7 +29,7 @@ Executable functions must return a tuple of:
 
 ### 2. State Management
 
-Easy and flexible wayto define the state management, what the agent sees and how that changes.
+Easy and flexible way to define the state management, what the agent sees and how that changes.
 
 ```python
 def get_state_fn(function_result: FunctionResult, current_state: dict) -> dict:
@@ -56,7 +56,7 @@ Key features:
 - Processes function execution results to update state
 
 ### 3. Workers
-Workers are simple interactiable agents that exectue the tasks defined by the user. They can be specialized agents with defined capabilities:
+Workers are simple interactiable agents that execute the tasks defined by the user. They can be specialized agents with defined capabilities:
 
 ```python
 worker = Worker(


### PR DESCRIPTION
Corrected `wayto` to `way to`
Corrected `exectue` to `execute`