### PR TITLE
Add pydantic dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "typing-extensions>=4.0.0",
     "requests>=2.26.0",
+    "pydantic>=2.0.0",
 ]
 
 


### PR DESCRIPTION
`custom_types.py` uses `pydantic` package which has not been included in `pyproject.toml`