### PR TITLE
[Chore] Add PR Templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+Click the `Preview` tab and select a PR template:
+
+- [Default Template](?expand=1&template=default.md)
+- [Plugin](?expand=1&template=plugin.md)

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,46 @@
+# Summary
+
+One-liner - what does this change?
+
+## Links
+
+- Jira/Notion:
+- Issue link:
+- Other useful links:
+
+## Changes
+
+(Answer where applicable)
+
+- Why this PR is needed?
+- What does this add?
+- What does this deprecate?
+- What does this improve?
+
+## Related Changes
+
+- Does this have a dependant PR? Eg. link to original PR if this is a bug fix PR.
+
+(Use table to list all related PRs if done in parts)
+
+| Description | PR |
+| --- | --- |
+| [Part 1] This PR | ⬅️ |
+| [Part 2] Another PR | link |
+| [Part 3] Another PR | link |
+
+## Dev Testing
+
+(Include where applicable)
+
+- Screenshots
+- Video Recordings
+
+## Pre-release Checklist
+
+- [ ] QA/PM's approval
+- [ ] (If files are removed) Check all usages of the deleted files
+
+## Rollback Steps
+
+- Any steps to follow in the event of rollback due to breaking release. Eg. toggle feature flag, revert commit etc.

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -2,16 +2,11 @@
 
 One-liner - what does this change?
 
-## Links
-
-- Jira/Notion:
-- Issue link:
-- Other useful links:
-
 ## Changes
 
 (Answer where applicable)
 
+- Important links (Jira/Notion/GitHub Issues):
 - Why this PR is needed?
 - What does this add?
 - What does this deprecate?
@@ -35,12 +30,3 @@ One-liner - what does this change?
 
 - Screenshots
 - Video Recordings
-
-## Pre-release Checklist
-
-- [ ] QA/PM's approval
-- [ ] (If files are removed) Check all usages of the deleted files
-
-## Rollback Steps
-
-- Any steps to follow in the event of rollback due to breaking release. Eg. toggle feature flag, revert commit etc.

--- a/.github/PULL_REQUEST_TEMPLATE/plugin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin.md
@@ -1,0 +1,49 @@
+# Summary
+
+One-liner – What does this plugin contribution add or change?
+
+## Links
+
+- Plugin documentation:
+- Issue link (if applicable):
+- Other useful links:
+
+## Description
+
+(Answer where applicable)
+
+- Why is this plugin contribution needed?
+- What functionality does this plugin add or enhance?
+- What dependencies or integrations does it introduce?
+
+## Plugin Details
+
+- Plugin Name:
+- Compatibility Notes (if applicable):
+- Additional Setup Instructions (if required):
+
+## Plugin Documentation Checklist
+
+- README Validation
+    - [ ] Clear installation instructions
+    - [ ] Usage examples with code snippets
+    - [ ] List of features and capabilities
+    - [ ] Troubleshooting guide (if applicable)
+    - [ ] Contribution guidelines (if applicable)
+
+- Metadata Validation
+    - [ ] Complete metadata provided in reference to [plugin metadata template](../.././plugins/plugin_metadata_template.yml)
+
+## Dev Testing
+
+(Include where applicable)
+
+- Screenshots/GIFs
+- Video Demonstrations
+- Logs or Console Outputs
+- Testing steps for the plugin
+
+## Additional Notes
+
+- Any considerations for future updates or enhancements.
+- Known issues or limitations with this plugin contribution.

--- a/.github/PULL_REQUEST_TEMPLATE/plugin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin.md
@@ -8,20 +8,6 @@ One-liner – What does this plugin contribution add or change?
 - Issue link (if applicable):
 - Other useful links:
 
-## Description
-
-(Answer where applicable)
-
-- Why is this plugin contribution needed?
-- What functionality does this plugin add or enhance?
-- What dependencies or integrations does it introduce?
-
-## Plugin Details
-
-- Plugin Name:
-- Compatibility Notes (if applicable):
-- Additional Setup Instructions (if required):
-
 ## Plugin Documentation Checklist
 
 - README Validation

--- a/plugins/plugin_metadata_template.yml
+++ b/plugins/plugin_metadata_template.yml
@@ -1,0 +1,23 @@
+# General Information
+plugin_name: ""           # Name of the plugin
+version: ""               # Current version (e.g., 1.0.0)
+author: ""                # Author or team name
+logo_url: ""              # URL to the author photo or team logo (512x512 recommended)
+release_date: ""          # Release date (DD-MM-YYYY)
+
+# Description
+short_description: ""      # One-liner description for listings
+detailed_description: ""   # Full description with features and benefits
+
+# Media & Assets
+plugin_logo_url: ""        # URL to the plugin logo (512x512 recommended)
+screenshots:               # List of screenshots showcasing the plugin
+  - ""                     # e.g., "https://example.com/screenshot1.png"
+  - ""
+demo_video_url: ""         # Link to a demo or walkthrough video (if available)
+documentation_url: ""      # Link to the plugin's official documentation (if available)
+changelog_url: ""          # Link to the changelog (if maintained)
+
+# Contact & Support
+support_contact: ""        # Email or Slack/Discord link for user support
+community_link: ""         # Forum or community link (if any)

--- a/plugins/plugin_metadata_template.yml
+++ b/plugins/plugin_metadata_template.yml
@@ -1,7 +1,6 @@
 # General Information
 plugin_name: ""           # Name of the plugin
-version: ""               # Current version (e.g., 1.0.0)
-author: ""                # Author or team name
+author: ""                # Author and team name
 logo_url: ""              # URL to the author photo or team logo (512x512 recommended)
 release_date: ""          # Release date (DD-MM-YYYY)
 
@@ -10,7 +9,7 @@ short_description: ""      # One-liner description for listings
 detailed_description: ""   # Full description with features and benefits
 
 # Media & Assets
-plugin_logo_url: ""        # URL to the plugin logo (512x512 recommended)
+plugin_logo_url: ""        # URL to the plugin logo (512x512 recommended) (if any or fallback to logo_url)
 screenshots:               # List of screenshots showcasing the plugin
   - ""                     # e.g., "https://example.com/screenshot1.png"
   - ""
@@ -19,5 +18,6 @@ documentation_url: ""      # Link to the plugin's official documentation (if ava
 changelog_url: ""          # Link to the changelog (if maintained)
 
 # Contact & Support
+x_account_handle: ""       # X (formerly known as Twitter) account handle (ie: @GAME_Virtuals)
 support_contact: ""        # Email or Slack/Discord link for user support
 community_link: ""         # Forum or community link (if any)


### PR DESCRIPTION
# Summary

Add PR templates for repo contributors to standardize PR documentation.

## Changes

- Current repo PRs are lack of standardization
- Introducing PR templates to standardize PR documentation for proper PR context
- Introduces PR template for default change/plugin contribution

## Dev Testing
Can be tested over the private [test repo](https://github.com/game-by-virtuals/test-repo/compare/Ang-dot-patch-13?expand=1).

[Video Recording](https://drive.google.com/file/d/1pAuek53SZrsiMFq_e1M8ZnyUSiXW8ncQ/view?usp=sharing)
    

