### PR TITLE
[CI] Add Auto PR Labeler

### DIFF
--- a/.github/pr-labeler-config.yml
+++ b/.github/pr-labeler-config.yml
@@ -1,0 +1,13 @@
+version: 1
+appendOnly: true
+labels:
+  - label: "bugfix"
+    title: "(?i)fix|bug"
+  - label: "documentation"
+    title: "(?i)docs|documentation"
+  - label: "enhancement"
+    title: "(?i)feat|feature|enhance|improve"
+  - label: "plugin"
+    title: "(?i)plugin"
+  - label: "test"
+    title: "(?i)test"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,20 @@
+name: Auto Label PR
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  label-plugin-pr:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Apply Labels
+        uses: srvaroa/labeler@master
+        with:
+          config_path: .github/pr-labeler-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary

Add auto PR labeler according to current use cases.

## Links

- GitHub Action Extension:
  [srvaroa/labeler](https://github.com/srvaroa/labeler): Label manager for PRs and Issues based on configurable conditions

## Changes

- Auto apply labels to future PRs based on the following PR title conditions:
  | Label | PR Title Regex |
  | --- | --- |
  | bugfix | (?i)fix\|bug |
  | documentation | (?i)docs\|documentation |
  | enhancement | (?i)feat\|feature\|enhance\|improve |
  | plugin | (?i)plugin |
  | test | (?i)test |

## Dev Testing
Can be tested over the private [test repo](https://github.com/game-by-virtuals/test-repo/compare/Ang-dot-patch-13?expand=1&title=plugin&template=default.md).

[Video Recording](https://drive.google.com/file/d/1GwQ7sM7TKRJc_45feICFpL9LbKfcV7zT/view?usp=sharing)
