### PR TITLE
fix: hosted GAME SDK endpoints expect strings from worldInfo

### DIFF
--- a/src/game_sdk/hosted_game/sdk.py
+++ b/src/game_sdk/hosted_game/sdk.py
@@ -36,6 +36,7 @@ class GameSDK:
                     "sessionId": session_id,
                     "goal": goal,
                     "description": description,
+                    "worldInfo": "",
                     "functions": functions,
                     "customFunctions": [x.toJson() for x in custom_functions]
                 }
@@ -60,6 +61,7 @@ class GameSDK:
             "sessionId": session_id,
             "goal": goal,
             "description": description,
+            "worldInfo": "",
             "functions": functions,
             "customFunctions": [x.toJson() for x in custom_functions]
         }


### PR DESCRIPTION
Click the `Preview` tab and select a PR template:

- [Default Template](?expand=1&template=default.md)
- [Plugin](?expand=1&template=plugin.md)
