### PR TITLE
Early casting of jobid or job_id to int

### DIFF
--- a/plugins/acp/README.md
+++ b/plugins/acp/README.md
@@ -155,7 +155,7 @@ agent = Agent(
         state = acp_plugin.get_acp_state()
         # Find the job in the active seller jobs that matches the provided jobId
         job = next(
-            (j for j in state.jobs.active.as_a_seller if j.job_id == int(jobId)),
+            (j for j in state.jobs.active.as_a_seller if j.job_id == jobId),
             None
         )
 
@@ -168,7 +168,7 @@ agent = Agent(
 
         # Add the generated product URL to the job's produced items
         acp_plugin.add_produce_item({
-            "jobId": int(jobId),
+            "jobId": jobId,
             "type": "url",
             "value": url
         })

--- a/plugins/acp/acp_plugin_gamesdk/acp_client.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_client.py
@@ -86,7 +86,7 @@ class AcpClient:
                     break
                 
                 if (data.get("status") == "success"):
-                    job_id = data.get("result").get("jobId")
+                    job_id = int(data.get("result").get("jobId"))
                     
                 if (job_id is not None and job_id != ""):
                     break  
@@ -102,7 +102,7 @@ class AcpClient:
             raise Exception("Failed to create job")
         
         self.acp_token.create_memo(
-                    job_id=int(job_id),
+                    job_id=job_id,
                     content=job_description,
                     memo_type=MemoType.MESSAGE,
                     is_secured=False,
@@ -110,7 +110,7 @@ class AcpClient:
                 )
 
         payload = {
-            "jobId": int(job_id),
+            "jobId": job_id,
             "clientAddress": self.agent_wallet_address,
             "providerAddress": provider_address,
             "description": job_description,
@@ -136,7 +136,7 @@ class AcpClient:
             time.sleep(5)
             
             return self.acp_token.create_memo(
-                job_id=int(job_id),
+                job_id=job_id,
                 content=f"Job {job_id} accepted. {reasoning}",
                 memo_type=MemoType.MESSAGE,
                 is_secured=False,
@@ -144,7 +144,7 @@ class AcpClient:
             )
         else:
             return self.acp_token.create_memo(
-                job_id=int(job_id),
+                job_id=job_id,
                 content=f"Job {job_id} rejected. {reasoning}",
                 memo_type=MemoType.MESSAGE,
                 is_secured=False,
@@ -163,7 +163,7 @@ class AcpClient:
 
     def deliver_job(self, job_id: int, deliverable: str):
         return self.acp_token.create_memo(
-            job_id=int(job_id),
+            job_id=job_id,
             content=deliverable,
             memo_type=MemoType.MESSAGE,
             is_secured=False,

--- a/plugins/acp/acp_plugin_gamesdk/acp_plugin.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_plugin.py
@@ -215,7 +215,7 @@ class AcpPlugin:
             args=[
                 {
                     "name": "jobId",
-                    "type": "string",
+                    "type": "integer",
                     "description": "The job ID you are responding to",
                 },
                 {
@@ -237,7 +237,7 @@ class AcpPlugin:
             executable=self._respond_job_executable
         )
 
-    def _respond_job_executable(self, jobId: str, decision: str, reasoning: str, tweetContent: str) -> Tuple[FunctionResultStatus, str, dict]:
+    def _respond_job_executable(self, jobId: int, decision: str, reasoning: str, tweetContent: str) -> Tuple[FunctionResultStatus, str, dict]:
         if not jobId:
             return FunctionResultStatus.FAILED, "Missing job ID - specify which job you're responding to", {}
         
@@ -251,7 +251,7 @@ class AcpPlugin:
             state = self.get_acp_state()
             
             job = next(
-                (c for c in state["jobs"]["active"]["asASeller"] if c["jobId"] == int(jobId)),
+                (c for c in state["jobs"]["active"]["asASeller"] if c["jobId"] == jobId),
                 None
             )
 
@@ -262,7 +262,7 @@ class AcpPlugin:
                 return FunctionResultStatus.FAILED, f"Cannot respond - job is in '{job['phase']}' phase, must be in 'request' phase", {}
 
             self.acp_client.response_job(
-                int(jobId),
+                jobId,
                 decision == "ACCEPT",
                 job["memo"][0]["id"],
                 reasoning
@@ -294,12 +294,12 @@ class AcpPlugin:
             args=[
                 {
                     "name": "jobId",
-                    "type": "number",
+                    "type": "integer",
                     "description": "The job ID you are paying for",
                 },
                 {
                     "name": "amount",
-                    "type": "number",
+                    "type": "float",
                     "description": "The total amount to pay",
                 },
                 {
@@ -316,7 +316,7 @@ class AcpPlugin:
             executable=self._pay_job_executable
         )
 
-    def _pay_job_executable(self, jobId: str, amount: str, reasoning: str, tweetContent: str) -> Tuple[FunctionResultStatus, str, dict]:
+    def _pay_job_executable(self, jobId: int, amount: float, reasoning: str, tweetContent: str) -> Tuple[FunctionResultStatus, str, dict]:
         if not jobId:
             return FunctionResultStatus.FAILED, "Missing job ID - specify which job you're paying for", {}
 
@@ -330,7 +330,7 @@ class AcpPlugin:
             state = self.get_acp_state()
             
             job = next(
-                (c for c in state["jobs"]["active"]["asABuyer"] if c["jobId"] == int(jobId)),
+                (c for c in state["jobs"]["active"]["asABuyer"] if c["jobId"] == jobId),
                 None
             )
 
@@ -342,8 +342,8 @@ class AcpPlugin:
 
 
             self.acp_client.make_payment(
-                int(jobId),
-                float(amount),
+                jobId,
+                amount,
                 job["memo"][0]["id"],
                 reasoning
             )
@@ -374,7 +374,7 @@ class AcpPlugin:
             args=[
                 {
                     "name": "jobId",
-                    "type": "string",
+                    "type": "integer",
                     "description": "The job ID you are delivering for",
                 },
                 {
@@ -401,7 +401,7 @@ class AcpPlugin:
             executable=self._deliver_job_executable
         )
 
-    def _deliver_job_executable(self, jobId: str, deliverableType: str, deliverable: str, reasoning: str, tweetContent: str) -> Tuple[FunctionResultStatus, str, dict]:
+    def _deliver_job_executable(self, jobId: int, deliverableType: str, deliverable: str, reasoning: str, tweetContent: str) -> Tuple[FunctionResultStatus, str, dict]:
         if not jobId:
             return FunctionResultStatus.FAILED, "Missing job ID - specify which job you're delivering for", {}
             
@@ -415,7 +415,7 @@ class AcpPlugin:
             state = self.get_acp_state()
             
             job = next(
-                (c for c in state["jobs"]["active"]["asASeller"] if c["jobId"] == int(jobId)),
+                (c for c in state["jobs"]["active"]["asASeller"] if c["jobId"] == jobId),
                 None
             )
 
@@ -439,7 +439,7 @@ class AcpPlugin:
             }
 
             self.acp_client.deliver_job(
-                int(jobId),
+                jobId,
                 json.dumps(deliverable),
             )
             

--- a/plugins/acp/examples/test_seller.py
+++ b/plugins/acp/examples/test_seller.py
@@ -68,14 +68,14 @@ def test():
         print(state)
         return state
     
-    def generate_meme(description: str, jobId: str, reasoning: str) -> Tuple[FunctionResultStatus, str, dict]:
+    def generate_meme(description: str, jobId: int, reasoning: str) -> Tuple[FunctionResultStatus, str, dict]:
         if not jobId or jobId == 'None':
             return FunctionResultStatus.FAILED, f"JobId is invalid. Should only respond to active as a seller job.", {}
 
         state = acp_plugin.get_acp_state()
         
         job = next(
-            (j for j in state.get('jobs').get('active').get('asASeller') if j.get('jobId') == int(jobId)),
+            (j for j in state.get('jobs').get('active').get('asASeller') if j.get('jobId') == jobId),
             None
         )
         
@@ -85,7 +85,7 @@ def test():
         url = "http://example.com/meme"
 
         acp_plugin.add_produce_item({
-            "jobId": int(jobId),
+            "jobId": jobId,
             "type": "url",
             "value": url
         })


### PR DESCRIPTION
# Summary

This casts job_id into an int at the first moment it is initialized. Getting rid of all the manual casting of job_ids to ints 
 using int(job_id)

## Changes

(Answer where applicable)

- Important links (Jira/Notion/GitHub Issues):
  - None
- Why this PR is needed?
  - Makes code cleaner
- What does this add?
  - Nothing
- What does this deprecate?
  - Nothing
- What does this improve?
  - Code readability and maintainability 

## Related Changes

- Does this have a dependent PR? Eg. link to original PR if this is a bug fix PR.
  - No

## Dev Testing

Tested on test_buyer.py:
![image](https://github.com/user-attachments/assets/0ec74f84-a812-4687-9a8b-5490d48ad7a5)

Output remains exactly the same
