### PR TITLE
Bugfix - Agents that have no offerings will trigger an error in the browse_agents function in AcpClient

### DIFF
--- a/plugins/acp/acp_plugin_gamesdk/acp_client.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_client.py
@@ -193,10 +193,8 @@ class AcpClient:
         return response.json()
     
     def reset_state(self) -> None:
-        address = self.acp_token.get_agent_wallet_address()
-        
         response = requests.delete(
-            f"{self.base_url}/states/{address}",
+            f"{self.base_url}/states/{self.agent_wallet_address}",
             headers={"x-api-key": self.api_key}
         )
         

--- a/plugins/acp/acp_plugin_gamesdk/acp_client.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_client.py
@@ -47,13 +47,18 @@ class AcpClient:
         result = []
         
         for agent in response_json.get("data", []):
+            if agent["offerings"]:
+                offerings = [AcpOffering(name=offering["name"], price=offering["price"]) for offering in agent["offerings"]]
+            else:
+                offerings = None
+
             result.append(
                 AcpAgent(
                     id=agent["id"],
                     name=agent["name"],
                     description=agent["description"],
                     wallet_address=agent["walletAddress"],
-                    offerings=[AcpOffering(name=offering["name"], price=offering["price"]) for offering in agent["offerings"]]
+                    offerings=offerings
                 )
             )
             
@@ -115,7 +120,8 @@ class AcpClient:
             "providerAddress": provider_address,
             "description": job_description,
             "price": price,
-            "expiredAt": expire_at.isoformat()
+            "expiredAt": expire_at.isoformat(),
+            "evaluatorAddress": self.agent_wallet_address
         }
 
         requests.post(

--- a/plugins/acp/acp_plugin_gamesdk/acp_client.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_client.py
@@ -192,11 +192,8 @@ class AcpClient:
         
         return response.json()
     
-    def reset_state(self, wallet_address: str ) -> None:
-        if not wallet_address:
-            raise Exception("Wallet address is required")
-        
-        address = wallet_address
+    def reset_state(self) -> None:
+        address = self.acp_token.get_agent_wallet_address()
         
         response = requests.delete(
             f"{self.base_url}/states/{address}",

--- a/plugins/acp/acp_plugin_gamesdk/interface.py
+++ b/plugins/acp/acp_plugin_gamesdk/interface.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import IntEnum, Enum
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 @dataclass
 class AcpOffering:
@@ -12,7 +12,7 @@ class AcpAgent:
     name: str
     description: str
     wallet_address: str
-    offerings: List[AcpOffering]
+    offerings: Optional[List[AcpOffering]]
     
 class AcpJobPhases(IntEnum):
     REQUEST = 0


### PR DESCRIPTION
# Summary

Fixes a bug that breaks browse_agents function

## Changes

(Answer where applicable)

- Important links (Jira/Notion/GitHub Issues):
  - None
- Why this PR is needed?
  - To fix a bug with browse_agent capabilities of ACP 
- What does this add?
  - Nothing
- What does this deprecate?
  - Nothing
- What does this improve?
  - It fixes a pretty breaking bug.

## Related Changes

- Does this have a dependant PR? Eg. link to original PR if this is a bug fix PR.
  - No

## Dev Testing

Screenshot of bug:
![image](https://github.com/user-attachments/assets/cd4e39f2-d7de-4b42-89cb-960283c7ce2b)
Agent is unable to browse for other agents

Caused by:
![image](https://github.com/user-attachments/assets/201926cb-43b4-4a40-80aa-c170a90e55d2)
Agents without any offerings

After bugfix:
![image](https://github.com/user-attachments/assets/83573118-a7d4-4b28-8a06-93d2beae5fb4)
Agent is able to browse for other agents

