### PR TITLE
Make agent exclude itself from search agent result

### DIFF
--- a/plugins/acp/acp_plugin_gamesdk/acp_client.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_client.py
@@ -34,7 +34,7 @@ class AcpClient:
         url += f"?filters[walletAddress][$notIn]={self.agent_wallet_address}"
 
         if query:
-            url += f"&_q={requests.utils.quote(query)}"
+            url += f"&search={requests.utils.quote(query)}"
             
         if cluster:
             url += f"&filters[cluster]={requests.utils.quote(cluster)}"

--- a/plugins/acp/acp_plugin_gamesdk/acp_client.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_client.py
@@ -29,14 +29,15 @@ class AcpClient:
 
     def browse_agents(self, cluster: Optional[str] = None, query: Optional[str] = None) -> List[AcpAgent]:
         url = f"{self.acp_base_url}/agents"
-        
+
+        # agent must exclude itself from search result to prevent self-commission
+        url += f"?filters[walletAddress][$notIn]={self.agent_wallet_address}"
+
         if query:
-            url += f"?search={requests.utils.quote(query)}"
+            url += f"&_q={requests.utils.quote(query)}"
             
         if cluster:
-            # Add & if there's already a parameter, otherwise add ?
-            separator = "&" if query else "?"
-            url += f"{separator}filters[cluster]={requests.utils.quote(cluster)}"
+            url += f"&filters[cluster]={requests.utils.quote(cluster)}"
 
         response = requests.get(url)
         


### PR DESCRIPTION
# Summary

- Currently, when the agent perform a `search_agents`, the `search_agents` function may return the said agent in the result. 
- This may lead to the agent to commission a job from itself. 
- To prevent self-commission, we will exclude the agent in the search result

## Related Changes

- Does this have a dependant PR? Eg. link to original PR if this is a bug fix PR.
https://github.com/Virtual-Protocol/acp-be/pull/45

## Changes

- Important links (Jira/Notion/GitHub Issues):
https://virtuals-protocol.atlassian.net/browse/ACP-162
https://github.com/game-by-virtuals/game-node/pull/117

- Why this PR is needed?
To prevent agents from commissioning ownself for jobs.