### PR TITLE
This should cater for all types in requireEvaluation

### DIFF
--- a/plugins/acp/acp_plugin_gamesdk/acp_plugin.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_plugin.py
@@ -293,6 +293,10 @@ class AcpPlugin:
     def _initiate_job_executable(self, sellerWalletAddress: str, price: str, reasoning: str, serviceRequirements: str, requireEvaluation: str, evaluatorKeyword: str, tweetContent: Optional[str] = None) -> Tuple[FunctionResultStatus, str, dict]:
         if isinstance(requireEvaluation, str):
             require_evaluation = requireEvaluation.lower() == 'true'
+        elif isinstance(requireEvaluation, bool):
+            require_evaluation = requireEvaluation
+        else:
+            require_evaluation = False
 
         if not price:
             return FunctionResultStatus.FAILED, "Missing price - specify how much you're offering per unit", {}


### PR DESCRIPTION
# Summary

Follow up to PR#99 this time we cater for requireEvaluation being sometimes string and sometimes boolean

## Changes

- Important links (Jira/Notion/GitHub Issues):
None
- Why this PR is needed?
To cast requireEvaluation to a boolean instead of a string
- What does this add?
Nothing
- What does this deprecate?
Nothing
- What does this improve?
Fixes a bug

## Dev Testing

