### PR TITLE
[Twitter Plugin] Improve Error Log

### DIFF
--- a/plugins/twitter/examples/.env.example
+++ b/plugins/twitter/examples/.env.example
@@ -1,0 +1,7 @@
+GAME_TWITTER_ACCESS_TOKEN=apx-<game-twitter-access-token>
+
+TWITTER_BEARER_TOKEN=<twitter-bearer-token>
+TWITTER_API_KEY=<twitter-api-key>
+TWITTER_API_SECRET_KEY=<twitter-api-secret-key>
+TWITTER_ACCESS_TOKEN=<twitter-access-token>
+TWITTER_ACCESS_TOKEN_SECRET=<twitter-access-token_secret>

--- a/plugins/twitter/examples/test_game_twitter.py
+++ b/plugins/twitter/examples/test_game_twitter.py
@@ -1,5 +1,8 @@
 import os
 from twitter_plugin_gamesdk.game_twitter_plugin import GameTwitterPlugin
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Define your options with the necessary credentials
 options = {

--- a/plugins/twitter/examples/test_twitter.py
+++ b/plugins/twitter/examples/test_twitter.py
@@ -1,5 +1,8 @@
 import os
 from twitter_plugin_gamesdk.twitter_plugin import TwitterPlugin
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Define your options with the necessary credentials
 options = {


### PR DESCRIPTION
# Summary

Adds an authentication gate during initialization of the `TwitterPlugin` & the `GameTwitterPlugin` to ensure valid credentials are provided before proceeding.

## Changes

- Adds a logging setup in the `TwitterPlugin` & the `GameTwitterPlugin` to provide authentication-related logs.
- Introduces an authentication check during initialization by calling the `_check_authentication()` method, which validates the credentials and logs the authentication status.

## Dev Testing
Tested locally.

- Screenshots

  | Plugin | Use Case | Before | After |
  | --- | --- | --- | --- |
  | `GameTwitterPlugin` | Empty `gameTwitterAccessToken` | <img alt="empty-gameTwitterAccessToken-before" src="https://github.com/user-attachments/assets/22702667-2800-4656-9907-a6b8578e9e95" /> | <img alt="empty-gameTwitterAccessToken-after" src="https://github.com/user-attachments/assets/3d61ee64-52ca-44f3-a3a6-04ae609f55ed" /> |
  | `GameTwitterPlugin` | Invalid `gameTwitterAccessToken` | <img alt="invalid-gameTwitterAccessToken-before" src="https://github.com/user-attachments/assets/22702667-2800-4656-9907-a6b8578e9e95" /> | <img alt="invalid-gameTwitterAccessToken-after" src="https://github.com/user-attachments/assets/3f63337a-c929-4654-babf-568f34253861" /> |
  | `GameTwitterPlugin` | Valid `gameTwitterAccessToken` | <img alt="valid-gameTwitterAccessToken-before" src="https://github.com/user-attachments/assets/25a17dd9-d403-409a-9a92-5e9796d871e1" /> | <img alt="valid-gameTwitterAccessToken-after" src="https://github.com/user-attachments/assets/b8677ed7-bd36-453f-a51f-f5e94793bc06" /> |
  | `TwitterPlugin` | Empty `bearerToken` | <img alt="empty-bearerToken-before" src="https://github.com/user-attachments/assets/80f48e65-ba3f-47dc-a363-1aa80c7fa7f8" /> | <img alt="empty-bearerToken-after" src="https://github.com/user-attachments/assets/31ac5a15-9455-4b7c-b369-33743dc8d1e6" /> |
  | `TwitterPlugin` | Empty `apiKey` | <img alt="empty-apiKey-before" src="https://github.com/user-attachments/assets/80f48e65-ba3f-47dc-a363-1aa80c7fa7f8" /> | <img alt="empty-apiKey-after" src="https://github.com/user-attachments/assets/fd48b39f-2fd2-4a87-ba46-a4282efe95f9" /> |
  | `TwitterPlugin` | Empty `apiSecretKey` | <img alt="empty-apiSecretKey-before" src="https://github.com/user-attachments/assets/80f48e65-ba3f-47dc-a363-1aa80c7fa7f8" /> | <img alt="empty-apiSecretKey-after" src="https://github.com/user-attachments/assets/8dffbaa9-4bdc-4027-858f-25dc50f1ffa4" /> |
  | `TwitterPlugin` | Empty `accessToken` | <img alt="empty-accessTokenSecret-before" src="https://github.com/user-attachments/assets/80f48e65-ba3f-47dc-a363-1aa80c7fa7f8" /> | <img alt="empty-accessToken-after" src="https://github.com/user-attachments/assets/68e6c75f-5e7a-4724-ae02-1b1388ec63ff" /> |
  | `TwitterPlugin` | Empty `accessTokenSecret` | <img alt="empty-accessTokenSecret-before" src="https://github.com/user-attachments/assets/80f48e65-ba3f-47dc-a363-1aa80c7fa7f8" /> | <img alt="empty-accessTokenSecret-after" src="https://github.com/user-attachments/assets/3b29b90f-7bb7-4b4f-8493-39a34a9767f2" /> |
  | `TwitterPlugin` | Invalid Twitter Plugin Credentials | <img alt="invalid-twitter-plugin-credentials-before" src="https://github.com/user-attachments/assets/2dea5e4e-55d2-43a1-9978-2d7f9d463a6a" /> | <img alt="invalid-twitter-plugin-credentials-after" src="https://github.com/user-attachments/assets/1a8a7752-01e0-4c85-a277-113432bb3862" /> |
  | `TwitterPlugin` | Valid Twitter Plugin Credentials | <img alt="valid-twitter-plugin-credentials-before" src="https://github.com/user-attachments/assets/a2a1edec-167b-4e77-ab17-c02266dcb887" /> | <img alt="valid-twitter-plugin-credentials-after" src="https://github.com/user-attachments/assets/658bd391-e2c4-4823-a9eb-d2f042326ddf" /> |