### PR TITLE
Bugfix - get state params 2

### DIFF
--- a/plugins/acp/acp_plugin_gamesdk/acp_plugin.py
+++ b/plugins/acp/acp_plugin_gamesdk/acp_plugin.py
@@ -168,7 +168,7 @@ class AcpPlugin:
             self.deliver_job,
         ]
         
-        def get_environment(_e, __) -> Dict[str, Any]:
+        def get_environment() -> Dict[str, Any]:
             environment = data.get_environment() if hasattr(data, "get_environment") else {}
             return {
                 **environment,


### PR DESCRIPTION
The default get state function when a worker is created has 2 useless params in it.