### PR TITLE
[ACP] Update Prompt in TRANSACTION Phase

### DIFF
--- a/plugins/acp/examples/reactive/seller.py
+++ b/plugins/acp/examples/reactive/seller.py
@@ -78,8 +78,6 @@ def seller():
             {job}
 
             you should produce the deliverable and deliver it to the buyer.
-
-            If no deliverable is provided, you should produce the deliverable and deliver it to the buyer.
             """
         else:
             out += "No need to react to the phase change\n\n"


### PR DESCRIPTION
## Summary:

This PR cleans up the prompt used during the TRANSACTION phase by removing a redundant line that duplicated existing instructions. The message now remains clear and concise.