### PR TITLE
[ACP] Add Cluster and Graduated Parameters to ACP Plugin Initialization

### DIFF
--- a/plugins/acp/examples/agentic/buyer.py
+++ b/plugins/acp/examples/agentic/buyer.py
@@ -68,6 +68,8 @@ def buyer():
                 entity_id=env.BUYER_ENTITY_ID
             ),
             twitter_plugin=TwitterPlugin(options),
+            cluster="<your_agent_cluster>",  # example cluster
+            graduated=True,
         )
     )
 

--- a/plugins/acp/examples/reactive/buyer.py
+++ b/plugins/acp/examples/reactive/buyer.py
@@ -89,7 +89,6 @@ def buyer():
                 on_new_task=on_new_task,
                 entity_id=env.BUYER_ENTITY_ID
             ),
-            twitter_plugin=TwitterPlugin(options)
             twitter_plugin=TwitterPlugin(options),
             cluster="<your_agent_cluster>", #example cluster
             graduated=True,
@@ -147,7 +146,10 @@ def buyer():
     agent = Agent(
         api_key=env.GAME_API_KEY,
         name="Virtuals",
+        agent_goal="Finding the best meme to do tweet posting",
         agent_description=f"""
+        Agent that gain market traction by posting meme. Your interest are in cats and AI. 
+        You can head to acp to look for agents to help you generating meme.
         Do not look for a relevant validator to validate the deliverable.
 
         {acp_plugin.agent_description}
@@ -170,6 +172,8 @@ def buyer():
         name="Buyer",
         agent_goal="Perform and complete transaction with seller",
         agent_description=f"""
+        Agent that gain market traction by posting meme. Your interest are in cats and AI. 
+        You can head to acp to look for agents to help you generating meme.
         Do not look for a relevant validator to validate the deliverable.
 
         {acp_plugin.agent_description}

--- a/plugins/acp/examples/reactive/buyer.py
+++ b/plugins/acp/examples/reactive/buyer.py
@@ -90,6 +90,9 @@ def buyer():
                 entity_id=env.BUYER_ENTITY_ID
             ),
             twitter_plugin=TwitterPlugin(options)
+            twitter_plugin=TwitterPlugin(options),
+            cluster="hedgefund", #example cluster
+            graduated=True,
         )
     )
 
@@ -144,10 +147,7 @@ def buyer():
     agent = Agent(
         api_key=env.GAME_API_KEY,
         name="Virtuals",
-        agent_goal="Finding the best meme to do tweet posting",
         agent_description=f"""
-        Agent that gain market traction by posting meme. Your interest are in cats and AI. 
-        You can head to acp to look for agents to help you generating meme.
         Do not look for a relevant validator to validate the deliverable.
 
         {acp_plugin.agent_description}
@@ -170,8 +170,6 @@ def buyer():
         name="Buyer",
         agent_goal="Perform and complete transaction with seller",
         agent_description=f"""
-        Agent that gain market traction by posting meme. Your interest are in cats and AI. 
-        You can head to acp to look for agents to help you generating meme.
         Do not look for a relevant validator to validate the deliverable.
 
         {acp_plugin.agent_description}

--- a/plugins/acp/examples/reactive/buyer.py
+++ b/plugins/acp/examples/reactive/buyer.py
@@ -91,7 +91,7 @@ def buyer():
             ),
             twitter_plugin=TwitterPlugin(options)
             twitter_plugin=TwitterPlugin(options),
-            cluster="hedgefund", #example cluster
+            cluster="<your_agent_cluster>", #example cluster
             graduated=True,
         )
     )


### PR DESCRIPTION
# PR Summary

This pull request enhances the ACP plugin initialization by adding support for the cluster and graduated parameters. Specifically:

- `cluster="<your_agent_cluster>"` was added to target a specific job cluster.
- `graduated=True` was introduced to explicitly specify agent graduation status.